### PR TITLE
Export hook decorators

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,3 +5,4 @@ export * from './decorators/Collection';
 export * from './decorators/OneToOne';
 export * from './decorators/OneToMany';
 export * from './decorators/Property';
+export * from './decorators/hooks';


### PR DESCRIPTION
Hey,
You probably forgot to export hook decorators. Because you are using them in your examples and they are not accessible from outside the project.